### PR TITLE
Fix regex strings

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -121,7 +121,7 @@ def set_log_level(args: argparse.Namespace):
 
 def parse_hms(value: str) -> int:
 
-    hms_pattern = re.compile("^([0-9]+h)?([0-9]+m)?([0-9]+s)?$")
+    hms_pattern = re.compile(r"^(\d+h)?(\d+m)?(\d+s)?$")
     hms_match = hms_pattern.match(value)
     if hms_match == None:
         raise ValueError(f"expected HMS formatted value, e.g. '2h15m10s', but got '{value}'")

--- a/src/backends/gnark/helper.py
+++ b/src/backends/gnark/helper.py
@@ -279,7 +279,7 @@ def run_metamorphic_tests \
     # report panics as they might be interesting
     reported_panics = set()
     for line in lines:
-        log_pattern = re.compile(".*Test_(C[1,2]_\d+_\d+): (.+)") # pyright: ignore
+        log_pattern = re.compile(r".*Test_(C[1,2]_\d+_\d+): (.+)") # pyright: ignore
         log_match = log_pattern.match(line)
         if log_match and log_match.group(1) and log_match.group(2):
             circuit_name = log_match.group(1)
@@ -301,7 +301,7 @@ def run_metamorphic_tests \
             elif "prove & verify => start" in log_msg:
                 online_tuning.inc_prove_and_verify_exec()
             else:
-                msg_pattern = re.compile("^([^\s]+)( time)? (c[1|2]) => ([^\s]+)$") # pyright: ignore
+                msg_pattern = re.compile(r"^([^\s]+)( time)? (c[1|2]) => ([^\s]+)$") # pyright: ignore
                 msg_match = msg_pattern.match(log_msg)
                 if msg_match != None:
                     subject = msg_match.group(1)
@@ -422,7 +422,7 @@ def run_metamorphic_tests \
                                 else:
                                     curr_iteration.c2_verify = value == "ok"
 
-        err_pattern = re.compile("--- FAIL: Test_(C[1,2]_\d+_\d+) ") # pyright: ignore
+        err_pattern = re.compile(r"--- FAIL: Test_(C[1,2]_\d+_\d+) ") # pyright: ignore
         err_match = err_pattern.match(line)
         if err_match and err_match.group(1):
             circuit_name = err_match.group(1)

--- a/src/backends/noir/helper.py
+++ b/src/backends/noir/helper.py
@@ -285,7 +285,7 @@ def analyze_metamorphic_relation \
                 # NOTE: having multiple assertions would be optimal, but noir only gives you the first
                 #       that fails, which is why instead of a subset we get the last assertion if present
                 #       and check for the assertion (id: <number>)
-                assertion_id_pattern = r"\(id: ([0-9]+)\)"
+                assertion_id_pattern = r"\(id: (\d+)\)"
                 match_origin = re.search(assertion_id_pattern, failed_assertion_orig_or_none)
                 match_tf = re.search(assertion_id_pattern, failed_assertion_tf_or_none)
                 assert match_origin != None and match_tf != None, "assertion had no id, generation error!"


### PR DESCRIPTION
This pr adds the missing `r` prefix before the regex strings. This is necessary because without it, `\d` is considered as an escape sequence and not as `\` followed by `d` (And it raises an annoying syntax warning on my system).
It also replaces the `[0-9]` pattern with `\d` where it's needed.